### PR TITLE
Offload sqlite to a worker thread to reduce profiling call latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,12 @@ WHERE Events.Kind = 'DEEPCOPY'
   AND Spans.Name LIKE '%SPGEMM%'
   AND Spans.Kind = 'REGION';
 ```
+
+## Contributing
+
+Format with clang-format-16
+
+```bash
+shopt -s globstar
+podman run --rm -v ${PWD}:/src ghcr.io/cwpearson/clang-format-16 clang-format -i *.[ch]pp {unit_test,perf_test}/**/*.[ch]pp
+```

--- a/kts.cpp
+++ b/kts.cpp
@@ -1,16 +1,16 @@
 
 
+#include <chrono>
+#include <condition_variable>
+#include <functional>
 #include <iostream>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
-#include <chrono>
-#include <string>
-#include <sstream>
-#include <thread>
-#include <queue>
-#include <functional>
-#include <mutex>
-#include <condition_variable>
 
 #include <sqlite3.h>
 
@@ -26,46 +26,45 @@ using TimePoint = std::chrono::time_point<Clock>;
 namespace lib {
 
 static uint64_t spanID = 0;
-static sqlite3* db = nullptr;
-static sqlite3_stmt* spanStmt = nullptr;
-static sqlite3_stmt* eventStmt = nullptr;
-
+static sqlite3 *db = nullptr;
+static sqlite3_stmt *spanStmt = nullptr;
+static sqlite3_stmt *eventStmt = nullptr;
 
 struct Span {
-    std::string name;
-    std::string kind;
-    TimePoint start;
+  std::string name;
+  std::string kind;
+  TimePoint start;
 
-    Span() = default;
-    Span(const std::string &_name, const std::string &_kind, const TimePoint &_start) : name(_name), kind(_kind), start(_start) {}
+  Span() = default;
+  Span(const std::string &_name, const std::string &_kind,
+       const TimePoint &_start)
+      : name(_name), kind(_kind), start(_start) {}
 };
 
 struct Event {
-    std::string name;
-    std::string kind;
+  std::string name;
+  std::string kind;
 
-    Event() = delete;
-    Event(const std::string &_name, const std::string &_kind) : name(_name), kind(_kind) {}
+  Event() = delete;
+  Event(const std::string &_name, const std::string &_kind)
+      : name(_name), kind(_kind) {}
 };
 
 static std::unordered_map<uint64_t, Span> spans;
 static std::vector<Span> regions;
-static const char * KIND_PARFOR = "PARALLEL_FOR";
-static const char * KIND_REGION = "REGION";
-static const char * KIND_DEEPCOPY = "DEEPCOPY";
-static const char * KIND_FENCE = "FENCE";
-
-
+static const char *KIND_PARFOR = "PARALLEL_FOR";
+static const char *KIND_REGION = "REGION";
+static const char *KIND_DEEPCOPY = "DEEPCOPY";
+static const char *KIND_FENCE = "FENCE";
 
 class Worker {
 public:
   Worker() : stop_(true) {}
 
-  template <typename F>
-  void add_job(F &&f) {
+  template <typename F> void add_job(F &&f) {
     {
-        std::unique_lock<std::mutex> lock(mutex_);
-        jobs_.emplace_back(std::forward<F>(f));
+      std::unique_lock<std::mutex> lock(mutex_);
+      jobs_.emplace_back(std::forward<F>(f));
     }
     cv_.notify_one();
   }
@@ -86,26 +85,26 @@ public:
   }
 
 private:
-
   void loop() {
-    
+
     // std::cerr << __FILE__ << ":" << __LINE__ << " worker loop...\n";
-    while(true) {
-        std::vector<std::function<void()>> jobs;
-        // std::cerr << __FILE__ << ":" << __LINE__ << " worker lock entry...\n";
-        {
-            std::unique_lock<std::mutex> lock(mutex_);
-            cv_.wait(lock, [this]{return !jobs_.empty() || stop_;});
-            if (stop_ && jobs_.empty()) {
-                return;
-            }
-            // quickly take all existing jobs
-            std::swap(jobs, jobs_);
+    while (true) {
+      std::vector<std::function<void()>> jobs;
+      // std::cerr << __FILE__ << ":" << __LINE__ << " worker lock entry...\n";
+      {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this] { return !jobs_.empty() || stop_; });
+        if (stop_ && jobs_.empty()) {
+          return;
         }
-        // std::cerr << __FILE__ << ":" << __LINE__ << " worker release... " << jobs.size() << "\n";
-        for (const auto &job : jobs) {
-            job();
-        }
+        // quickly take all existing jobs
+        std::swap(jobs, jobs_);
+      }
+      // std::cerr << __FILE__ << ":" << __LINE__ << " worker release... " <<
+      // jobs.size() << "\n";
+      for (const auto &job : jobs) {
+        job();
+      }
     }
   }
 
@@ -120,126 +119,130 @@ private:
 static Worker worker;
 
 static void begin_transaction() {
-    char* errMsg = 0;
-    int rc = sqlite3_exec(db, "BEGIN IMMEDIATE", 0, 0, &errMsg);
-    if (rc != SQLITE_OK) {
-        fprintf(stderr, "begin_transaction: SQL error: %s\n", errMsg);
-        sqlite3_free(errMsg);
-        sqlite3_close(db);
-        exit(1);
-    }
+  char *errMsg = 0;
+  int rc = sqlite3_exec(db, "BEGIN IMMEDIATE", 0, 0, &errMsg);
+  if (rc != SQLITE_OK) {
+    fprintf(stderr, "begin_transaction: SQL error: %s\n", errMsg);
+    sqlite3_free(errMsg);
+    sqlite3_close(db);
+    exit(1);
+  }
 }
 
 static void commit_transaction() {
-    char* errMsg = 0;
-    int rc = sqlite3_exec(db, "COMMIT", 0, 0, &errMsg);
-    if (rc != SQLITE_OK) {
-        fprintf(stderr, "commit_transaction: SQL error: %s\n", errMsg);
-        sqlite3_free(errMsg);
-        sqlite3_close(db);
-        exit(1);
-    }
+  char *errMsg = 0;
+  int rc = sqlite3_exec(db, "COMMIT", 0, 0, &errMsg);
+  if (rc != SQLITE_OK) {
+    fprintf(stderr, "commit_transaction: SQL error: %s\n", errMsg);
+    sqlite3_free(errMsg);
+    sqlite3_close(db);
+    exit(1);
+  }
 }
 
 void init() {
-    std::cerr << "==== libkts.so: init ====\n";
-    std::cerr << __FILE__ << ":" << __LINE__ << " " << kts_mpi_rank() << "\n";
-    worker.start();
-    const char* sqlitePrefix = std::getenv("KTS_SQLITE_PREFIX");
-    if (!sqlitePrefix) {
-        sqlitePrefix = "kts_";
+  std::cerr << "==== libkts.so: init ====\n";
+  std::cerr << __FILE__ << ":" << __LINE__ << " " << kts_mpi_rank() << "\n";
+  worker.start();
+  const char *sqlitePrefix = std::getenv("KTS_SQLITE_PREFIX");
+  if (!sqlitePrefix) {
+    sqlitePrefix = "kts_";
+  }
+
+  std::string sqlitePath =
+      std::string(sqlitePrefix) + std::to_string(kts_mpi_rank()) + ".sqlite";
+  {
+    std::cerr << __FILE__ << ":" << __LINE__ << " open " << sqlitePath << "\n";
+    int rc = sqlite3_open(sqlitePath.c_str(), &db);
+    if (rc) {
+      std::cerr << "Can't open database: " << sqlite3_errmsg(db) << std::endl;
+      exit(1);
     }
+  }
 
-    std::string sqlitePath = std::string(sqlitePrefix) + std::to_string(kts_mpi_rank()) + ".sqlite";
-    {
-        std::cerr << __FILE__ << ":" << __LINE__ << " open " << sqlitePath << "\n";
-        int rc = sqlite3_open(sqlitePath.c_str(), &db);
-        if (rc) {
-            std::cerr << "Can't open database: " << sqlite3_errmsg(db) << std::endl;
-            exit(1);
-        }
+  begin_transaction();
+
+  // create Spans table
+  {
+    const char *createTableSQL = "CREATE TABLE IF NOT EXISTS Spans("
+                                 "ID INTEGER PRIMARY KEY AUTOINCREMENT,"
+                                 "Name TEXT NOT NULL,"
+                                 "Kind TEXT NOT NULL,"
+                                 "Start REAL NOT NULL,"
+                                 "Stop REAL NOT NULL);";
+
+    char *errMsg = 0;
+    int rc = sqlite3_exec(db, createTableSQL, 0, 0, &errMsg);
+    if (rc != SQLITE_OK) {
+      std::cerr << "SQL error: " << errMsg << std::endl;
+      sqlite3_free(errMsg);
     }
+  }
 
-    begin_transaction();
+  // create Events table
+  {
+    const char *createTableSQL = "CREATE TABLE IF NOT EXISTS Events("
+                                 "ID INTEGER PRIMARY KEY AUTOINCREMENT,"
+                                 "Name TEXT NOT NULL,"
+                                 "Kind TEXT NOT NULL,"
+                                 "Time REAL NOT NULL);";
 
-    // create Spans table
-    {
-        const char* createTableSQL = "CREATE TABLE IF NOT EXISTS Spans("
-                                    "ID INTEGER PRIMARY KEY AUTOINCREMENT,"
-                                    "Name TEXT NOT NULL,"
-                                    "Kind TEXT NOT NULL,"
-                                    "Start REAL NOT NULL,"
-                                    "Stop REAL NOT NULL);";
-
-        char* errMsg = 0;
-        int rc = sqlite3_exec(db, createTableSQL, 0, 0, &errMsg);
-        if (rc != SQLITE_OK) {
-            std::cerr << "SQL error: " << errMsg << std::endl;
-            sqlite3_free(errMsg);
-        }
+    char *errMsg = 0;
+    int rc = sqlite3_exec(db, createTableSQL, 0, 0, &errMsg);
+    if (rc != SQLITE_OK) {
+      std::cerr << "SQL error: " << errMsg << std::endl;
+      sqlite3_free(errMsg);
     }
+  }
 
-    // create Events table
-    {
-        const char* createTableSQL = "CREATE TABLE IF NOT EXISTS Events("
-                                    "ID INTEGER PRIMARY KEY AUTOINCREMENT,"
-                                    "Name TEXT NOT NULL,"
-                                    "Kind TEXT NOT NULL,"
-                                    "Time REAL NOT NULL);";
+  commit_transaction();
 
-        char* errMsg = 0;
-        int rc = sqlite3_exec(db, createTableSQL, 0, 0, &errMsg);
-        if (rc != SQLITE_OK) {
-            std::cerr << "SQL error: " << errMsg << std::endl;
-            sqlite3_free(errMsg);
-        }
+  // prepare Span insertion statement
+  {
+    const char *insertSQL =
+        "INSERT INTO Spans (Name, Kind, Start, Stop) VALUES (?, ?, ?, ?);";
+    int rc = sqlite3_prepare_v2(db, insertSQL, -1, &spanStmt, 0);
+    if (rc != SQLITE_OK) {
+      std::cerr << "Failed to prepare statement: " << sqlite3_errmsg(db)
+                << std::endl;
+      sqlite3_close(db);
+      exit(1);
     }
+  }
 
-    commit_transaction();
-
-    // prepare Span insertion statement
-    {
-        const char* insertSQL = "INSERT INTO Spans (Name, Kind, Start, Stop) VALUES (?, ?, ?, ?);";
-        int rc = sqlite3_prepare_v2(db, insertSQL, -1, &spanStmt, 0);
-        if (rc != SQLITE_OK) {
-            std::cerr << "Failed to prepare statement: " << sqlite3_errmsg(db) << std::endl;
-            sqlite3_close(db);
-            exit(1);
-        }
+  // prepare Event insertion statement
+  {
+    const char *insertSQL =
+        "INSERT INTO Events (Name, Kind, Time) VALUES (?, ?, ?);";
+    int rc = sqlite3_prepare_v2(db, insertSQL, -1, &eventStmt, 0);
+    if (rc != SQLITE_OK) {
+      std::cerr << "Failed to prepare statement: " << sqlite3_errmsg(db)
+                << std::endl;
+      sqlite3_close(db);
+      exit(1);
     }
+  }
 
-    // prepare Event insertion statement
-    {
-        const char* insertSQL = "INSERT INTO Events (Name, Kind, Time) VALUES (?, ?, ?);";
-        int rc = sqlite3_prepare_v2(db, insertSQL, -1, &eventStmt, 0);
-        if (rc != SQLITE_OK) {
-            std::cerr << "Failed to prepare statement: " << sqlite3_errmsg(db) << std::endl;
-            sqlite3_close(db);
-            exit(1);
-        }
-    }
-
-    begin_transaction();
+  begin_transaction();
 }
 
 void finalize() {
-    std::cerr << "==== libkts.so: finalize ====\n";
+  std::cerr << "==== libkts.so: finalize ====\n";
 
-    worker.join();
-    commit_transaction();
-    sqlite3_finalize(spanStmt);
-    sqlite3_finalize(eventStmt);
-    sqlite3_close(db);
-    db = nullptr;
+  worker.join();
+  commit_transaction();
+  sqlite3_finalize(spanStmt);
+  sqlite3_finalize(eventStmt);
+  sqlite3_close(db);
+  db = nullptr;
 }
 
 static void record_span(const Span &span, TimePoint &&stop) {
 
-    worker.add_job([=]{
-
+  worker.add_job([=] {
     const char *name = span.name.c_str();
     if (!name) {
-        name = "<null name>";
+      name = "<null name>";
     }
     sqlite3_bind_text(spanStmt, 1, name, -1, SQLITE_STATIC);
     sqlite3_bind_text(spanStmt, 2, span.kind.c_str(), -1, SQLITE_STATIC);
@@ -249,27 +252,23 @@ static void record_span(const Span &span, TimePoint &&stop) {
     int rc = sqlite3_step(spanStmt);
 
     if (rc != SQLITE_DONE) {
-        std::cerr << "Execution failed: " << sqlite3_errmsg(db) << std::endl;
-        std::cerr << "Span was:" 
-                    << " " << span.name 
-                    << " " << span.kind
-                    << " " << span.start.time_since_epoch().count()
-                    << " " << stop.time_since_epoch().count()
-                    << "\n";
-        exit(1);
+      std::cerr << "Execution failed: " << sqlite3_errmsg(db) << std::endl;
+      std::cerr << "Span was:"
+                << " " << span.name << " " << span.kind << " "
+                << span.start.time_since_epoch().count() << " "
+                << stop.time_since_epoch().count() << "\n";
+      exit(1);
     }
     sqlite3_reset(spanStmt);
-
-    });
+  });
 }
 
 static void record_event(const Event &event, const TimePoint &time) {
 
-    worker.add_job([=]{
-
+  worker.add_job([=] {
     const char *name = event.name.c_str();
     if (!name) {
-        name = "<null name>";
+      name = "<null name>";
     }
     sqlite3_bind_text(eventStmt, 1, name, -1, SQLITE_STATIC);
     sqlite3_bind_text(eventStmt, 2, event.kind.c_str(), -1, SQLITE_STATIC);
@@ -279,71 +278,70 @@ static void record_event(const Event &event, const TimePoint &time) {
     int rc = sqlite3_step(eventStmt);
 
     if (rc != SQLITE_DONE) {
-        std::cerr << "Execution failed: " << sqlite3_errmsg(db) << std::endl;
-        std::cerr << "Event was:" 
-                    << " " << event.name 
-                    << " " << event.kind
-                    << " " << time.time_since_epoch().count()
-                    << "\n";
-        exit(1);
+      std::cerr << "Execution failed: " << sqlite3_errmsg(db) << std::endl;
+      std::cerr << "Event was:"
+                << " " << event.name << " " << event.kind << " "
+                << time.time_since_epoch().count() << "\n";
+      exit(1);
     }
     sqlite3_reset(eventStmt);
-
-    });
+  });
 }
 
 // returns a unique id
-uint64_t begin_parallel_for(const char* name, const uint32_t devID) {
-    uint64_t kID = spanID++;
-    spans[kID] = Span(name, std::string(KIND_PARFOR) + "[" + std::to_string(devID) + "]", Clock::now());
-    return kID;
+uint64_t begin_parallel_for(const char *name, const uint32_t devID) {
+  uint64_t kID = spanID++;
+  spans[kID] =
+      Span(name, std::string(KIND_PARFOR) + "[" + std::to_string(devID) + "]",
+           Clock::now());
+  return kID;
 }
 
 // accepts the return value of the corresponding begin_parallel_for
 void end_parallel_for(const uint64_t kID) {
-    record_span(spans[kID], Clock::now());
-    spans.erase(kID);
+  record_span(spans[kID], Clock::now());
+  spans.erase(kID);
 }
-
 
 void push_profile_region(const char *name) {
-    spanID++;
-    regions.emplace_back(name, KIND_REGION, Clock::now());
+  spanID++;
+  regions.emplace_back(name, KIND_REGION, Clock::now());
 }
 void pop_profile_region() {
-    if (!regions.empty()) {
-        record_span(regions.back(), Clock::now());
-        regions.pop_back();
-    }
+  if (!regions.empty()) {
+    record_span(regions.back(), Clock::now());
+    regions.pop_back();
+  }
 }
 
-void begin_deep_copy(const char *dstSpaceName, const char *dstName, const void *dst_ptr, const char *srcSpaceName, const char *srcName, const void *src_ptr, uint64_t size) {
+void begin_deep_copy(const char *dstSpaceName, const char *dstName,
+                     const void *dst_ptr, const char *srcSpaceName,
+                     const char *srcName, const void *src_ptr, uint64_t size) {
 
-    (void) dst_ptr;
-    (void) srcName;
-    (void) src_ptr;
+  (void)dst_ptr;
+  (void)srcName;
+  (void)src_ptr;
 
-    std::stringstream ss;
-    ss 
-      << srcName
-      << "[" << srcSpaceName << "]"
-      << "->" << dstName
-      << "[" << dstSpaceName << "]"
-      << "(" << size << ")";
-    record_event(Event(ss.str(), KIND_DEEPCOPY), Clock::now());
+  std::stringstream ss;
+  ss << srcName << "[" << srcSpaceName << "]"
+     << "->" << dstName << "[" << dstSpaceName << "]"
+     << "(" << size << ")";
+  record_event(Event(ss.str(), KIND_DEEPCOPY), Clock::now());
 }
 
 // returns a unique id
-uint64_t begin_fence(const char* name, const uint32_t devID) {
-    uint64_t kID = spanID++;
-    spans[kID] = Span(name, std::string(KIND_FENCE) + "[" + std::to_string(devID) + "]", Clock::now());
-    return kID;
+uint64_t begin_fence(const char *name, const uint32_t devID) {
+  uint64_t kID = spanID++;
+  spans[kID] =
+      Span(name, std::string(KIND_FENCE) + "[" + std::to_string(devID) + "]",
+           Clock::now());
+  return kID;
 }
 
 // accepts the return value of the corresponding begin_fence
 void end_fence(const uint64_t kID) {
-    record_span(spans[kID], Clock::now());
-    spans.erase(kID);
+  record_span(spans[kID], Clock::now());
+  spans.erase(kID);
 }
 
-}
+} // namespace lib

--- a/kts.hpp
+++ b/kts.hpp
@@ -4,15 +4,12 @@
 
 namespace lib {
 
-
 void init();
 
 void finalize();
 
-
-
 // returns a unique id
-uint64_t begin_parallel_for(const char* name, const uint32_t devID);
+uint64_t begin_parallel_for(const char *name, const uint32_t devID);
 
 // accepts the return value of the corresponding begin_parallel_for
 void end_parallel_for(const uint64_t kID);
@@ -20,10 +17,12 @@ void end_parallel_for(const uint64_t kID);
 void push_profile_region(const char *name);
 void pop_profile_region();
 
-void begin_deep_copy(const char *dstSpaceName, const char *dstName, const void *dst_ptr, const char *srcSpaceName, const char *srcName, const void *src_ptr, uint64_t size);
+void begin_deep_copy(const char *dstSpaceName, const char *dstName,
+                     const void *dst_ptr, const char *srcSpaceName,
+                     const char *srcName, const void *src_ptr, uint64_t size);
 
 // returns a unique id
-uint64_t begin_fence(const char* name, const uint32_t devID);
+uint64_t begin_fence(const char *name, const uint32_t devID);
 
 // accepts the return value of the corresponding begin_fence
 void end_fence(const uint64_t kID);

--- a/kts_pid.cpp
+++ b/kts_pid.cpp
@@ -11,37 +11,37 @@
 #endif
 
 static int kts_mpi_rank_impl() {
-    int rank = 0;
+  int rank = 0;
 #if defined(KTS_ENABLE_MPI)
-    int initialized;
-    MPI_Initialized(&initialized);
-    if (initialized) {
-        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    }
-    return rank;
+  int initialized;
+  MPI_Initialized(&initialized);
+  if (initialized) {
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  }
+  return rank;
 #else
-    {
-        const char * ompiCommWorldRank = std::getenv("OMPI_COMM_WORLD_RANK");
-        if (ompiCommWorldRank && std::string_view(ompiCommWorldRank) != "") {
-            rank = std::atoi(ompiCommWorldRank);
-            return rank;
-        }
+  {
+    const char *ompiCommWorldRank = std::getenv("OMPI_COMM_WORLD_RANK");
+    if (ompiCommWorldRank && std::string_view(ompiCommWorldRank) != "") {
+      rank = std::atoi(ompiCommWorldRank);
+      return rank;
     }
+  }
 #if defined(KTS_HAVE_GETPID)
-    {
-        rank = getpid();
-        return rank;
-    }
+  {
+    rank = getpid();
+    return rank;
+  }
 #endif // KTS_HAVE_GETPID
 #endif // KTS_ENABLE_MPI
 }
 
 int kts_mpi_rank() {
-    static bool once = true;
-    static int rank;
-    if (once) {
-        rank = kts_mpi_rank_impl();
-        once = false;
-    }
-    return rank;
+  static bool once = true;
+  static int rank;
+  if (once) {
+    rank = kts_mpi_rank_impl();
+    once = false;
+  }
+  return rank;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -15,11 +15,11 @@
 //@HEADER
 
 #include <cstdio>
-#include <inttypes.h>
-#include <vector>
-#include <string>
-#include <limits>
 #include <cstring>
+#include <inttypes.h>
+#include <limits>
+#include <string>
+#include <vector>
 
 #include "kts.hpp"
 
@@ -30,19 +30,16 @@ struct SpaceHandle {
 extern "C" void kokkosp_init_library(const int loadSeq,
                                      const uint64_t interfaceVer,
                                      const uint32_t /*devInfoCount*/,
-                                     void* /*deviceInfo*/) {
-
+                                     void * /*deviceInfo*/) {
 
   lib::init();
 }
 
-extern "C" void kokkosp_finalize_library() {
-  lib::finalize();
-}
+extern "C" void kokkosp_finalize_library() { lib::finalize(); }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name,
+extern "C" void kokkosp_begin_parallel_for(const char *name,
                                            const uint32_t devID,
-                                           uint64_t* kID) {
+                                           uint64_t *kID) {
   *kID = lib::begin_parallel_for(name, devID);
 }
 
@@ -50,26 +47,24 @@ extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
   lib::end_parallel_for(kID);
 }
 
-
-extern "C" void kokkosp_push_profile_region(char* regionName) {
+extern "C" void kokkosp_push_profile_region(char *regionName) {
   lib::push_profile_region(regionName);
 }
 
-extern "C" void kokkosp_pop_profile_region() {
-  lib::pop_profile_region();
-}
+extern "C" void kokkosp_pop_profile_region() { lib::pop_profile_region(); }
 
 extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
-                                        const char* dst_name,
-                                        const void* dst_ptr,
+                                        const char *dst_name,
+                                        const void *dst_ptr,
                                         SpaceHandle src_handle,
-                                        const char* src_name,
-                                        const void* src_ptr, uint64_t size) {
-  lib::begin_deep_copy(dst_handle.name, dst_name, dst_ptr, src_handle.name, src_name, src_ptr, size);
+                                        const char *src_name,
+                                        const void *src_ptr, uint64_t size) {
+  lib::begin_deep_copy(dst_handle.name, dst_name, dst_ptr, src_handle.name,
+                       src_name, src_ptr, size);
 }
 
-extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
-                                    uint64_t* kID) {
+extern "C" void kokkosp_begin_fence(const char *name, const uint32_t devID,
+                                    uint64_t *kID) {
   // filter out fence as this is a duplicate and unneeded (causing the tool to
   // hinder performance of application). We use strstr for checking if the
   // string contains the label of a fence (we assume the user will always have

--- a/perf_test/CMakeLists.txt
+++ b/perf_test/CMakeLists.txt
@@ -19,3 +19,4 @@ endfunction()
 
 kts_add_bench(perf_fence perf_fence.cpp)
 kts_add_bench(perf_parfor perf_parfor.cpp)
+kts_add_bench(perf_deepcopy perf_deepcopy.cpp)

--- a/perf_test/perf_deepcopy.cpp
+++ b/perf_test/perf_deepcopy.cpp
@@ -10,6 +10,6 @@ static void BM_deepcopy(benchmark::State& state) {
   }
 }
 // Register the function as a benchmark
-BENCHMARK(BM_deepcopy);
+BENCHMARK(BM_deepcopy)->UseRealTime();
 
 KTS_BENCHMARK_MAIN();

--- a/perf_test/perf_deepcopy.cpp
+++ b/perf_test/perf_deepcopy.cpp
@@ -2,8 +2,7 @@
 
 #include "perf_main.hpp"
 
-
-static void BM_deepcopy(benchmark::State& state) {
+static void BM_deepcopy(benchmark::State &state) {
   Kokkos::View<double *> a("a", 0), b("b", 0);
   for (auto _ : state) {
     Kokkos::deep_copy(b, a);

--- a/perf_test/perf_fence.cpp
+++ b/perf_test/perf_fence.cpp
@@ -2,8 +2,7 @@
 
 #include "perf_main.hpp"
 
-
-static void BM_fence(benchmark::State& state) {
+static void BM_fence(benchmark::State &state) {
   for (auto _ : state) {
     Kokkos::fence();
   }

--- a/perf_test/perf_fence.cpp
+++ b/perf_test/perf_fence.cpp
@@ -9,6 +9,6 @@ static void BM_fence(benchmark::State& state) {
   }
 }
 // Register the function as a benchmark
-BENCHMARK(BM_fence);
+BENCHMARK(BM_fence)->UseRealTime();
 
 KTS_BENCHMARK_MAIN();

--- a/perf_test/perf_main.hpp
+++ b/perf_test/perf_main.hpp
@@ -1,54 +1,54 @@
 #pragma once
 
-#include <iostream>
 #include <filesystem>
+#include <iostream>
 
 #include <benchmark/benchmark.h>
 
-// delete everything in the parent of KTS_SQLITE_PREFIX that has the $KTS_SQLITE_PREFIX(anything).sqlite
+// delete everything in the parent of KTS_SQLITE_PREFIX that has the
+// $KTS_SQLITE_PREFIX(anything).sqlite
 inline static void delete_database() {
 
-    namespace fs = std::filesystem;
+  namespace fs = std::filesystem;
 
-    const char *rawPrefixPath = std::getenv("KTS_SQLITE_PREFIX");
-    if (!rawPrefixPath) {
-        return;
+  const char *rawPrefixPath = std::getenv("KTS_SQLITE_PREFIX");
+  if (!rawPrefixPath) {
+    return;
+  }
+  const fs::path prefixPath(fs::absolute(rawPrefixPath));
+  const fs::path prefixDir = prefixPath.parent_path();
+  if (!fs::exists(prefixDir) || !fs::is_directory(prefixDir)) {
+    std::cerr << "Directory does not exist or is not a directory.\n";
+    return;
+  }
+
+  const std::string prefix = prefixPath.filename().string();
+  const std::string suffix = ".sqlite";
+  for (const auto &entry : fs::directory_iterator(prefixDir)) {
+    if (entry.is_regular_file()) {
+      const auto &path = entry.path();
+      const auto &filename = path.filename().string();
+
+      if (filename.size() >= prefix.size() + suffix.size() &&
+          filename.compare(0, prefix.size(), prefix) == 0 &&
+          filename.compare(filename.size() - suffix.size(), suffix.size(),
+                           suffix) == 0) {
+        std::cerr << __FILE__ << ":" << __LINE__ << " remove " << path << "\n";
+        fs::remove(path);
+      }
     }
-    const fs::path prefixPath(fs::absolute(rawPrefixPath));
-    const fs::path prefixDir = prefixPath.parent_path();
-    if (!fs::exists(prefixDir) || !fs::is_directory(prefixDir)) {
-        std::cerr << "Directory does not exist or is not a directory.\n";
-        return;
-    }
-
-    const std::string prefix = prefixPath.filename().string();
-    const std::string suffix = ".sqlite";
-    for (const auto& entry : fs::directory_iterator(prefixDir)) {
-        if (entry.is_regular_file()) {
-            const auto& path = entry.path();
-            const auto& filename = path.filename().string();
-
-            if (filename.size() >= prefix.size() + suffix.size() &&
-                filename.compare(0, prefix.size(), prefix) == 0 &&
-                filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) == 0) {
-                std::cerr << __FILE__ << ":" << __LINE__ << " remove " << path << "\n";
-                fs::remove(path);
-            }
-        }
-    }
-
-
+  }
 }
 
-#define KTS_BENCHMARK_MAIN() \
-int main(int argc, char** argv) {\
-    setenv("KTS_SQLITE_PREFIX", "kts_perf_test_", false);\
-    delete_database();\
-    Kokkos::initialize();\
-    ::benchmark::Initialize(&argc, argv);\
-    ::benchmark::RunSpecifiedBenchmarks();\
-    ::benchmark::Shutdown();\
-    Kokkos::finalize();\
-    delete_database();\
-    return 0;\
-}
+#define KTS_BENCHMARK_MAIN()                                                   \
+  int main(int argc, char **argv) {                                            \
+    setenv("KTS_SQLITE_PREFIX", "kts_perf_test_", false);                      \
+    delete_database();                                                         \
+    Kokkos::initialize();                                                      \
+    ::benchmark::Initialize(&argc, argv);                                      \
+    ::benchmark::RunSpecifiedBenchmarks();                                     \
+    ::benchmark::Shutdown();                                                   \
+    Kokkos::finalize();                                                        \
+    delete_database();                                                         \
+    return 0;                                                                  \
+  }

--- a/perf_test/perf_parfor.cpp
+++ b/perf_test/perf_parfor.cpp
@@ -2,8 +2,7 @@
 
 #include "perf_main.hpp"
 
-
-static void BM_parfor(benchmark::State& state) {
+static void BM_parfor(benchmark::State &state) {
   for (auto _ : state) {
     Kokkos::parallel_for(0, KOKKOS_LAMBDA(int){});
   }

--- a/perf_test/perf_parfor.cpp
+++ b/perf_test/perf_parfor.cpp
@@ -9,6 +9,6 @@ static void BM_parfor(benchmark::State& state) {
   }
 }
 // Register the function as a benchmark
-BENCHMARK(BM_parfor);
+BENCHMARK(BM_parfor)->UseRealTime();
 
 KTS_BENCHMARK_MAIN();

--- a/unit_test/test_deep_copy.cpp
+++ b/unit_test/test_deep_copy.cpp
@@ -1,16 +1,17 @@
 #include <Kokkos_Core.hpp>
 
 int main(void) {
-    Kokkos::initialize(); {
+  Kokkos::initialize();
+  {
 
     {
-        Kokkos::View<double *> a("a", 10), b("b", 10);
-        Kokkos::deep_copy(b, a);
+      Kokkos::View<double *> a("a", 10), b("b", 10);
+      Kokkos::deep_copy(b, a);
     }
     {
-        Kokkos::View<double *> a("a", 10);
-        Kokkos::deep_copy(a, 17.0);
+      Kokkos::View<double *> a("a", 10);
+      Kokkos::deep_copy(a, 17.0);
     }
-
-    } Kokkos::finalize();
+  }
+  Kokkos::finalize();
 }

--- a/unit_test/test_parfor.cpp
+++ b/unit_test/test_parfor.cpp
@@ -1,8 +1,11 @@
 #include <Kokkos_Core.hpp>
 
 int main(void) {
-    Kokkos::initialize(); {
-    std::stringstream ss; ss << __FILE__ << ":" << __LINE__;
+  Kokkos::initialize();
+  {
+    std::stringstream ss;
+    ss << __FILE__ << ":" << __LINE__;
     Kokkos::parallel_for(ss.str(), 10, KOKKOS_LAMBDA(int){});
-    } Kokkos::finalize();
+  }
+  Kokkos::finalize();
 }

--- a/unit_test/test_view_init.cpp
+++ b/unit_test/test_view_init.cpp
@@ -1,7 +1,7 @@
 #include <Kokkos_Core.hpp>
 
 int main(void) {
-    Kokkos::initialize(); {
-    Kokkos::View<double *> a("a", 10);
-    } Kokkos::finalize();
+  Kokkos::initialize();
+  { Kokkos::View<double *> a("a", 10); }
+  Kokkos::finalize();
 }


### PR DESCRIPTION
Previously, the profiling calls would block on sqlite. Now they just dump the thing to be recorded into a queue that a worker thread reads from.